### PR TITLE
video 업로드, Stream 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,5 +41,8 @@ dependencies {
     compileOnly('io.jsonwebtoken:jjwt-api:0.11.2')
     runtimeOnly('io.jsonwebtoken:jjwt-impl:0.11.2')
     runtimeOnly('io.jsonwebtoken:jjwt-jackson:0.11.2')
+
+    //guava
+    implementation("com.google.guava:guava:30.1-jre")
 }
 

--- a/src/main/java/me/hoyoung/youtube/config/auth/JwtTokenProvider.java
+++ b/src/main/java/me/hoyoung/youtube/config/auth/JwtTokenProvider.java
@@ -73,8 +73,12 @@ public class JwtTokenProvider {
     }
 
     public Boolean validateToken(String token) {
-        final String id = getIdFromToken(token);
-        return (userService.checkUserExistById(id) && !isTokenExpired(token));
+        try {
+            final String id = getIdFromToken(token);
+            return (userService.checkUserExistById(id) && !isTokenExpired(token));
+        } catch (Exception ex) {
+            return false;
+        }
     }
 
     public String resolveToken(HttpServletRequest request) {

--- a/src/main/java/me/hoyoung/youtube/config/auth/SecurityConfig.java
+++ b/src/main/java/me/hoyoung/youtube/config/auth/SecurityConfig.java
@@ -22,6 +22,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             "/api/v1/user/signin",
             "/api/v1/user/signup",
             "/h2-console/**",
+            "/api/v1/video/view/**"
     };
 
     @Override

--- a/src/main/java/me/hoyoung/youtube/domain/user/User.java
+++ b/src/main/java/me/hoyoung/youtube/domain/user/User.java
@@ -3,6 +3,7 @@ package me.hoyoung.youtube.domain.user;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import me.hoyoung.youtube.domain.video.Video;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -10,6 +11,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -31,6 +33,9 @@ public class User implements UserDetails {
 
     @Column
     private String role = Role.USER.getKey();
+
+    @OneToMany(mappedBy = "uploader")
+    private List<Video> videos = new ArrayList<>();
 
     @Builder
     public User(String id, String name, String password) {

--- a/src/main/java/me/hoyoung/youtube/domain/video/Drive.java
+++ b/src/main/java/me/hoyoung/youtube/domain/video/Drive.java
@@ -1,0 +1,12 @@
+package me.hoyoung.youtube.domain.video;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+
+public interface Drive {
+    String createFile(MultipartFile file) throws IOException;
+    File getFile(String originName) throws IOException;
+    void delete(String filename) throws IOException;
+}

--- a/src/main/java/me/hoyoung/youtube/domain/video/Video.java
+++ b/src/main/java/me/hoyoung/youtube/domain/video/Video.java
@@ -1,5 +1,6 @@
 package me.hoyoung.youtube.domain.video;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import me.hoyoung.youtube.domain.user.User;
@@ -20,16 +21,24 @@ public class Video {
     private String id;
 
     @ManyToOne
-    @JoinColumn(name = "uuid")
+    @JoinColumn
     private User uploader;
 
-    @Column(nullable = false)
+    @Column(name="original_FileName", nullable = false)
     private String originalFileName;
 
     @Column
     private String thumbnailPath;
 
-    @Column(nullable = false)
+    @Column(name="created_date", nullable = false)
     private Timestamp createdDate;
+
+    @Builder
+    public Video(User uploader, String originalFileName, String thumbnailPath, Timestamp createdDate) {
+        this.uploader = uploader;
+        this.originalFileName = originalFileName;
+        this.thumbnailPath = thumbnailPath;
+        this.createdDate = createdDate;
+    }
 
 }

--- a/src/main/java/me/hoyoung/youtube/domain/video/Video.java
+++ b/src/main/java/me/hoyoung/youtube/domain/video/Video.java
@@ -1,0 +1,35 @@
+package me.hoyoung.youtube.domain.video;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.hoyoung.youtube.domain.user.User;
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+import java.sql.Timestamp;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Video {
+
+    @Id
+    @GenericGenerator(name = "uuid_gen", strategy = "uuid2")
+    @GeneratedValue(generator = "uuid_gen")
+    @Column(nullable = false, unique = true)
+    private String id;
+
+    @ManyToOne
+    @JoinColumn(name = "uuid")
+    private User uploader;
+
+    @Column(nullable = false)
+    private String originalFileName;
+
+    @Column
+    private String thumbnailPath;
+
+    @Column(nullable = false)
+    private Timestamp createdDate;
+
+}

--- a/src/main/java/me/hoyoung/youtube/domain/video/VideoDrive.java
+++ b/src/main/java/me/hoyoung/youtube/domain/video/VideoDrive.java
@@ -14,11 +14,12 @@ import java.nio.file.Paths;
 import java.util.UUID;
 
 @Service
-public class VideoDrive {
+public class VideoDrive implements Drive {
 
     @Value("${video.storage.dir}")
     private String directory;
 
+    @Override
     public String createFile(MultipartFile file) throws IOException{
         String fileName = String.format(
                 "%s.%s",
@@ -36,11 +37,13 @@ public class VideoDrive {
         return fileName;
     }
 
+    @Override
     public File getFile(String originName) throws IOException {
         String location = directory + originName;
         return new File(location);
     }
 
+    @Override
     public void delete(String filename) throws IOException {
         File file = new File(directory + filename);
         if (file.exists()) {

--- a/src/main/java/me/hoyoung/youtube/domain/video/VideoDrive.java
+++ b/src/main/java/me/hoyoung/youtube/domain/video/VideoDrive.java
@@ -30,23 +30,18 @@ public class VideoDrive {
             dir.mkdirs();
         }
 
-        String location = this.getLocation() + fileName;
-        Path path = Paths.get(location);
+        Path path = Paths.get(directory + fileName);
         Files.write(path, file.getBytes());
-        return location;
+        return fileName;
     }
 
     public byte[] getFile(String originName) throws IOException {
-        String location = this.getLocation() + originName;
+        String location = directory + originName;
         File file = new File(location);
         byte[] b = null;
         if (file.exists()) {
             b = Files.readAllBytes(file.toPath());
         }
         return b;
-    }
-
-    public String getLocation() {
-        return new StringBuilder(directory).append(File.separator).toString();
     }
 }

--- a/src/main/java/me/hoyoung/youtube/domain/video/VideoDrive.java
+++ b/src/main/java/me/hoyoung/youtube/domain/video/VideoDrive.java
@@ -30,18 +30,23 @@ public class VideoDrive {
             dir.mkdirs();
         }
 
-        String location = new StringBuilder(directory).append(File.separator).append(fileName).toString();
+        String location = this.getLocation() + fileName;
         Path path = Paths.get(location);
         Files.write(path, file.getBytes());
         return location;
     }
 
-    public byte[] getFile(String path) throws IOException {
-        File file = new File(path);
+    public byte[] getFile(String originName) throws IOException {
+        String location = this.getLocation() + originName;
+        File file = new File(location);
         byte[] b = null;
         if (file.exists()) {
             b = Files.readAllBytes(file.toPath());
         }
         return b;
+    }
+
+    public String getLocation() {
+        return new StringBuilder(directory).append(File.separator).toString();
     }
 }

--- a/src/main/java/me/hoyoung/youtube/domain/video/VideoDrive.java
+++ b/src/main/java/me/hoyoung/youtube/domain/video/VideoDrive.java
@@ -35,13 +35,8 @@ public class VideoDrive {
         return fileName;
     }
 
-    public byte[] getFile(String originName) throws IOException {
+    public File getFile(String originName) throws IOException {
         String location = directory + originName;
-        File file = new File(location);
-        byte[] b = null;
-        if (file.exists()) {
-            b = Files.readAllBytes(file.toPath());
-        }
-        return b;
+        return new File(location);
     }
 }

--- a/src/main/java/me/hoyoung/youtube/domain/video/VideoDrive.java
+++ b/src/main/java/me/hoyoung/youtube/domain/video/VideoDrive.java
@@ -1,0 +1,47 @@
+package me.hoyoung.youtube.domain.video;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+@Service
+public class VideoDrive {
+
+    @Value("${video.storage.dir}")
+    private String directory;
+
+    public String createFile(MultipartFile file) throws IOException{
+        String fileName = String.format(
+                "%s.%s",
+                UUID.randomUUID().toString(),
+                StringUtils.getFilenameExtension(file.getOriginalFilename())
+        );
+
+        File dir = new File(directory);
+        if (!dir.exists()) {
+            dir.mkdirs();
+        }
+
+        String location = new StringBuilder(directory).append(File.separator).append(fileName).toString();
+        Path path = Paths.get(location);
+        Files.write(path, file.getBytes());
+        return location;
+    }
+
+    public byte[] getFile(String path) throws IOException {
+        File file = new File(path);
+        byte[] b = null;
+        if (file.exists()) {
+            b = Files.readAllBytes(file.toPath());
+        }
+        return b;
+    }
+}

--- a/src/main/java/me/hoyoung/youtube/domain/video/VideoDrive.java
+++ b/src/main/java/me/hoyoung/youtube/domain/video/VideoDrive.java
@@ -6,6 +6,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -38,5 +39,16 @@ public class VideoDrive {
     public File getFile(String originName) throws IOException {
         String location = directory + originName;
         return new File(location);
+    }
+
+    public void delete(String filename) throws IOException {
+        File file = new File(directory + filename);
+        if (file.exists()) {
+            if (!file.delete()) {
+                throw new IOException("비디오를 삭제할 수 없습니다.");
+            }
+        } else {
+            throw new FileNotFoundException("비디오를 찾을 수 없습니다.");
+        }
     }
 }

--- a/src/main/java/me/hoyoung/youtube/domain/video/VideoRepository.java
+++ b/src/main/java/me/hoyoung/youtube/domain/video/VideoRepository.java
@@ -1,0 +1,9 @@
+package me.hoyoung.youtube.domain.video;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface VideoRepository extends JpaRepository<Video, Long> {
+    Video findById(String id);
+}

--- a/src/main/java/me/hoyoung/youtube/service/VideoService.java
+++ b/src/main/java/me/hoyoung/youtube/service/VideoService.java
@@ -2,8 +2,8 @@ package me.hoyoung.youtube.service;
 
 import lombok.RequiredArgsConstructor;
 import me.hoyoung.youtube.domain.user.User;
+import me.hoyoung.youtube.domain.video.Drive;
 import me.hoyoung.youtube.domain.video.Video;
-import me.hoyoung.youtube.domain.video.VideoDrive;
 import me.hoyoung.youtube.domain.video.VideoRepository;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -20,7 +20,7 @@ import java.time.LocalDateTime;
 @Service
 public class VideoService {
     private final VideoRepository videoRepository;
-    private final VideoDrive videoDrive;
+    private final Drive videoDrive;
 
     @Transactional
     public Video createFile(MultipartFile file) throws IOException {

--- a/src/main/java/me/hoyoung/youtube/service/VideoService.java
+++ b/src/main/java/me/hoyoung/youtube/service/VideoService.java
@@ -1,0 +1,26 @@
+package me.hoyoung.youtube.service;
+
+import lombok.RequiredArgsConstructor;
+import me.hoyoung.youtube.domain.video.Video;
+import me.hoyoung.youtube.domain.video.VideoRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Service
+public class VideoService {
+    private final VideoRepository videoRepository;
+
+    public Video createFile(MultipartFile file) {
+        Video video = Video.builder()
+                .originalFileName(file.getName().toString())
+                .createdDate(Timestamp.valueOf(LocalDateTime.now()))
+                .build();
+
+        return videoRepository.save(video);
+    }
+
+}

--- a/src/main/java/me/hoyoung/youtube/service/VideoService.java
+++ b/src/main/java/me/hoyoung/youtube/service/VideoService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.security.sasl.AuthenticationException;
 import java.io.File;
 import java.io.IOException;
 import java.sql.Timestamp;
@@ -43,5 +44,16 @@ public class VideoService {
 
     public File getFile(String originName) throws IOException {
         return videoDrive.getFile(originName);
+    }
+
+    @Transactional
+    public void delete(Video video) throws IOException {
+        User user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if (video.getUploader() == user) {
+            videoDrive.delete(video.getOriginalFileName());
+            videoRepository.delete(video);
+        } else {
+            throw new AuthenticationException("삭제할 수 없습니다.");
+        }
     }
 }

--- a/src/main/java/me/hoyoung/youtube/service/VideoService.java
+++ b/src/main/java/me/hoyoung/youtube/service/VideoService.java
@@ -7,8 +7,10 @@ import me.hoyoung.youtube.domain.video.VideoDrive;
 import me.hoyoung.youtube.domain.video.VideoRepository;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.File;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
@@ -19,6 +21,7 @@ public class VideoService {
     private final VideoRepository videoRepository;
     private final VideoDrive videoDrive;
 
+    @Transactional
     public Video createFile(MultipartFile file) throws IOException {
         String filename = videoDrive.createFile(file);
 
@@ -38,8 +41,7 @@ public class VideoService {
         return videoRepository.findById(id);
     }
 
-    public byte[] getFile(String originName) throws IOException {
+    public File getFile(String originName) throws IOException {
         return videoDrive.getFile(originName);
     }
-
 }

--- a/src/main/java/me/hoyoung/youtube/service/VideoService.java
+++ b/src/main/java/me/hoyoung/youtube/service/VideoService.java
@@ -1,9 +1,11 @@
 package me.hoyoung.youtube.service;
 
 import lombok.RequiredArgsConstructor;
+import me.hoyoung.youtube.domain.user.User;
 import me.hoyoung.youtube.domain.video.Video;
 import me.hoyoung.youtube.domain.video.VideoDrive;
 import me.hoyoung.youtube.domain.video.VideoRepository;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -20,8 +22,10 @@ public class VideoService {
     public Video createFile(MultipartFile file) throws IOException {
         String filename = videoDrive.createFile(file);
 
+        User user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
         Video video = Video.builder()
-                .originalFileName(file.getName())
+                .uploader(user)
                 .createdDate(Timestamp.valueOf(LocalDateTime.now()))
                 .originalFileName(filename)
                 .build();

--- a/src/main/java/me/hoyoung/youtube/service/VideoService.java
+++ b/src/main/java/me/hoyoung/youtube/service/VideoService.java
@@ -2,10 +2,12 @@ package me.hoyoung.youtube.service;
 
 import lombok.RequiredArgsConstructor;
 import me.hoyoung.youtube.domain.video.Video;
+import me.hoyoung.youtube.domain.video.VideoDrive;
 import me.hoyoung.youtube.domain.video.VideoRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 
@@ -13,12 +15,17 @@ import java.time.LocalDateTime;
 @Service
 public class VideoService {
     private final VideoRepository videoRepository;
+    private final VideoDrive videoDrive;
 
-    public Video createFile(MultipartFile file) {
+    public Video createFile(MultipartFile file) throws IOException {
+        String filename = videoDrive.createFile(file);
+
         Video video = Video.builder()
-                .originalFileName(file.getName().toString())
+                .originalFileName(file.getName())
                 .createdDate(Timestamp.valueOf(LocalDateTime.now()))
+                .originalFileName(filename)
                 .build();
+
 
         return videoRepository.save(video);
     }

--- a/src/main/java/me/hoyoung/youtube/service/VideoService.java
+++ b/src/main/java/me/hoyoung/youtube/service/VideoService.java
@@ -30,4 +30,12 @@ public class VideoService {
         return videoRepository.save(video);
     }
 
+    public Video findById(String id) {
+        return videoRepository.findById(id);
+    }
+
+    public byte[] getFile(String originName) throws IOException {
+        return videoDrive.getFile(originName);
+    }
+
 }

--- a/src/main/java/me/hoyoung/youtube/web/api/VideoController.java
+++ b/src/main/java/me/hoyoung/youtube/web/api/VideoController.java
@@ -4,13 +4,10 @@ import lombok.RequiredArgsConstructor;
 import me.hoyoung.youtube.domain.video.Video;
 import me.hoyoung.youtube.service.VideoService;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-
-import static org.springframework.http.ResponseEntity.ok;
 
 @RequiredArgsConstructor
 @RestController
@@ -24,11 +21,9 @@ public class VideoController {
             consumes = {
                     MediaType.MULTIPART_FORM_DATA_VALUE,
                     MediaType.APPLICATION_OCTET_STREAM_VALUE})
-    public ResponseEntity<?> createVideo(
+    public void createVideo(
             @RequestPart("content") MultipartFile file) throws IOException {
         String contentType = file.getContentType();
-
         Video metaData = videoService.createFile(file);
-        return ok(metaData);
     }
 }

--- a/src/main/java/me/hoyoung/youtube/web/api/VideoController.java
+++ b/src/main/java/me/hoyoung/youtube/web/api/VideoController.java
@@ -6,8 +6,9 @@ import me.hoyoung.youtube.service.VideoService;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
-import java.io.IOException;
+import java.io.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -25,5 +26,35 @@ public class VideoController {
             @RequestPart("content") MultipartFile file) throws IOException {
         String contentType = file.getContentType();
         Video metaData = videoService.createFile(file);
+    }
+
+    @GetMapping(value = "/view/{id}", produces = "video/mp4")
+    public StreamingResponseBody getVideoStream(@PathVariable("id") String id) throws IOException {
+        Video video = videoService.findById(id);
+        File file = videoService.getFile(video.getOriginalFileName());
+        final InputStream is = new FileInputStream(file);
+
+        return os -> {
+            readAndWrite(is, os);
+        };
+    }
+
+    private void readAndWrite(final InputStream is, OutputStream os) {
+        try {
+            byte[] data = new byte[4096];
+            int read = 0;
+            while ((read = is.read(data)) > 0) {
+                os.write(data, 0, read);
+                os.flush();
+            }
+        } catch(IOException ex) {
+
+        } finally {
+            try {
+                is.close();
+                os.close();
+            } catch(IOException ex) {
+            }
+        }
     }
 }

--- a/src/main/java/me/hoyoung/youtube/web/api/VideoController.java
+++ b/src/main/java/me/hoyoung/youtube/web/api/VideoController.java
@@ -57,4 +57,10 @@ public class VideoController {
             }
         }
     }
+
+    @DeleteMapping("/delete/{id}")
+    public void deleteVideo(@PathVariable("id") String id) throws IOException {
+        Video video = videoService.findById(id);
+        videoService.delete(video);
+    }
 }

--- a/src/main/java/me/hoyoung/youtube/web/api/VideoController.java
+++ b/src/main/java/me/hoyoung/youtube/web/api/VideoController.java
@@ -1,0 +1,34 @@
+package me.hoyoung.youtube.web.api;
+
+import lombok.RequiredArgsConstructor;
+import me.hoyoung.youtube.domain.video.Video;
+import me.hoyoung.youtube.service.VideoService;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+import static org.springframework.http.ResponseEntity.ok;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/video")
+public class VideoController {
+
+    private final VideoService videoService;
+
+    @PostMapping(
+            value = "/upload",
+            consumes = {
+                    MediaType.MULTIPART_FORM_DATA_VALUE,
+                    MediaType.APPLICATION_OCTET_STREAM_VALUE})
+    public ResponseEntity<?> createVideo(
+            @RequestPart("content") MultipartFile file) throws IOException {
+        String contentType = file.getContentType();
+
+        Video metaData = videoService.createFile(file);
+        return ok(metaData);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,7 @@ spring.datasource.hikari.username=sa
 spring.h2.console.enabled=true
 spring.profiles.include=oauth
 spring.session.store-type=jdbc
+spring.jpa.hibernate.ddl-auto=create-drop
+
+spring.servlet.multipart.max-file-size=500MB
+spring.servlet.multipart.max-request-size=500MB

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,5 @@ spring.jpa.hibernate.ddl-auto=create-drop
 
 spring.servlet.multipart.max-file-size=500MB
 spring.servlet.multipart.max-request-size=500MB
+
+video.storage.dir=C:/test/

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,4 +11,4 @@ spring.jpa.hibernate.ddl-auto=create-drop
 spring.servlet.multipart.max-file-size=500MB
 spring.servlet.multipart.max-request-size=500MB
 
-video.storage.dir=C:/test/
+video.storage.dir=C:\\test\\

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,5 @@ spring.servlet.multipart.max-file-size=500MB
 spring.servlet.multipart.max-request-size=500MB
 
 video.storage.dir=C:\\test\\
+
+spring.mvc.async.request-timeout = 3600000

--- a/src/test/java/me/hoyoung/youtube/domain/video/VideoDriveTest.java
+++ b/src/test/java/me/hoyoung/youtube/domain/video/VideoDriveTest.java
@@ -14,6 +14,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -65,6 +66,23 @@ public class VideoDriveTest {
         File createFile = new File(directory + createdFileName);
         assertThat(createFile.exists()).isTrue();
     }
+
+    @Test
+    @DisplayName("비디오 getFile 테스트")
+    public void getFileTest() throws Exception {
+        //given
+        String contents = UUID.randomUUID().toString() + "TestTestTestTestTestTest";
+        MultipartFile multipartFile =  createTestRandomFile(contents);
+        String createdFileName = videoDrive.createFile(multipartFile);
+
+        //when
+        File getFile = videoDrive.getFile(createdFileName);
+
+        //then
+        String readContents = com.google.common.io.Files.asCharSource(getFile, StandardCharsets.UTF_8).read();
+        assertThat(readContents).isEqualTo(contents);
+    }
+
     public MultipartFile createTestRandomFile(String contents) throws Exception {
         String filename = UUID.randomUUID().toString() + testExtension;
         byte[] contentBytes = contents.getBytes();

--- a/src/test/java/me/hoyoung/youtube/domain/video/VideoDriveTest.java
+++ b/src/test/java/me/hoyoung/youtube/domain/video/VideoDriveTest.java
@@ -53,11 +53,7 @@ public class VideoDriveTest {
     @DisplayName("비디오 createFile 테스트")
     public void createFileTest() throws Exception {
         //given
-        String filename = UUID.randomUUID().toString() + testExtension;
-        byte[] contents = "Test contents".getBytes();
-        Path path = Paths.get(directory + filename);
-        Files.write(path, contents);
-        MultipartFile multipartFile = new MockMultipartFile(filename, filename, "text/plain",  new FileInputStream(new File(directory + filename)));
+        MultipartFile multipartFile = createTestRandomFile("Test contents");
 
         //when
         String createdFileName = videoDrive.createFile(multipartFile);

--- a/src/test/java/me/hoyoung/youtube/domain/video/VideoDriveTest.java
+++ b/src/test/java/me/hoyoung/youtube/domain/video/VideoDriveTest.java
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
@@ -18,6 +17,7 @@ import java.io.FileInputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,6 +32,8 @@ public class VideoDriveTest {
     @Value("${video.storage.dir}")
     private String directory;
 
+    private String testExtension = ".tests";
+
     @BeforeEach
     public void createDir() {
         File dir = new File(directory);
@@ -40,11 +42,17 @@ public class VideoDriveTest {
         }
     }
 
+    @AfterEach
+    public void cleanUp() {
+        final File[] files = new File(directory).listFiles((dir, name) -> name.matches( ".+("+ testExtension +")$" ));
+        Arrays.stream(files).forEach((file) -> file.delete());
+    }
+
     @Test
     @DisplayName("비디오 createFile 테스트")
     public void userSignUpTest() throws Exception {
         //given
-        String filename = UUID.randomUUID().toString() + ".tests";
+        String filename = UUID.randomUUID().toString() + testExtension;
         byte[] contents = "Test contents".getBytes();
         Path path = Paths.get(directory + filename);
         Files.write(path, contents);

--- a/src/test/java/me/hoyoung/youtube/domain/video/VideoDriveTest.java
+++ b/src/test/java/me/hoyoung/youtube/domain/video/VideoDriveTest.java
@@ -1,0 +1,60 @@
+package me.hoyoung.youtube.domain.video;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class VideoDriveTest {
+
+    @Autowired
+    private VideoDrive videoDrive;
+
+    @Value("${video.storage.dir}")
+    private String directory;
+
+    @BeforeEach
+    public void createDir() {
+        File dir = new File(directory);
+        if (!dir.exists()) {
+            dir.mkdirs();
+        }
+    }
+
+    @Test
+    @DisplayName("비디오 createFile 테스트")
+    public void userSignUpTest() throws Exception {
+        //given
+        String filename = UUID.randomUUID().toString() + ".tests";
+        byte[] contents = "Test contents".getBytes();
+        Path path = Paths.get(directory + filename);
+        Files.write(path, contents);
+        MultipartFile multipartFile = new MockMultipartFile(filename, filename, "text/plain",  new FileInputStream(new File(directory + filename)));
+
+        //when
+        String createdFileName = videoDrive.createFile(multipartFile);
+
+        //then
+        File createFile = new File(directory + createdFileName);
+        assertThat(createFile.exists()).isTrue();
+    }
+}

--- a/src/test/java/me/hoyoung/youtube/domain/video/VideoDriveTest.java
+++ b/src/test/java/me/hoyoung/youtube/domain/video/VideoDriveTest.java
@@ -50,7 +50,7 @@ public class VideoDriveTest {
 
     @Test
     @DisplayName("비디오 createFile 테스트")
-    public void userSignUpTest() throws Exception {
+    public void createFileTest() throws Exception {
         //given
         String filename = UUID.randomUUID().toString() + testExtension;
         byte[] contents = "Test contents".getBytes();

--- a/src/test/java/me/hoyoung/youtube/domain/video/VideoDriveTest.java
+++ b/src/test/java/me/hoyoung/youtube/domain/video/VideoDriveTest.java
@@ -65,4 +65,12 @@ public class VideoDriveTest {
         File createFile = new File(directory + createdFileName);
         assertThat(createFile.exists()).isTrue();
     }
+    public MultipartFile createTestRandomFile(String contents) throws Exception {
+        String filename = UUID.randomUUID().toString() + testExtension;
+        byte[] contentBytes = contents.getBytes();
+        Path path = Paths.get(directory + filename);
+        Files.write(path, contentBytes);
+        return new MockMultipartFile(filename, filename, "text/plain",  new FileInputStream(new File(directory + filename)));
+    }
+
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+video.storage.dir=C:\\test\\


### PR DESCRIPTION
- Video 업로드하는 API를 구현
  - Video를 업로드 하면 DB에 랜덤으로 생성된 파일이름과 랜덤으로 생성된 ID(PK)가 저장됨
  - 디스크에는 랜덤으로 생성된 파일이름으로 동영상이 저장됨
  - 유저가 요청할 땐 랜덤ID로 요청하도록 구현
    - 이렇게 구현한 이유는 랜덤 ID로 파일을 저장하면 URL을 알면 video에 직접 접근할 수 있을 거 같아서 이런 방식으로 구현

- Video 스트림 API 구현
  - Video를 저장할 때 생성된 랜덤ID로 API 요청하면 스트림으로 반환됨
  - StreamingResponseBody을 이용해 구현

- VideoDrive 테스트 구현